### PR TITLE
Try detecting libffi with pkg-config first, fall-back to plainly use the library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,10 @@ project('xs', ['cpp'])
   compile_flags = ['-I../src', '-Wall', '-Wextra']
   link_flags = []
   boost_dep = dependency('boost')
-  ffi_lib = compiler.find_library('ffi')
+  ffi_lib = dependency('libffi', required: false)
+  if not ffi_lib.found()
+    ffi_lib = compiler.find_library('ffi')
+  endif
   gc_lib = compiler.find_library('gc')
   readline_lib = compiler.find_library('readline')
   custom_target('.stamp',


### PR DESCRIPTION
In some GNU/Linux distributions (example: Arch Linux) the headers for `libffi` are installed in a location which is not in the default compiler search path, and a `libffi.pc` file is provided to allow discovery of the needed build flags using `pkg-config`.

With this fix applied, Meson will try first to find `libffi` using `pkg-config`, and if not found, fall-back to `compiler.find_library()` which will still cover systems which do not install a `.pc` file and provide the `libffi` headers in a standard location.

This fixes the following compilation error:

```
FAILED: xsdump@exe/src_prim-etc.cxx.o
c++  -Ixsdump@exe -I. -I.. -I../src -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -O0 -g -Wall -Wextra -MMD -MQ 'xsdump@exe/src_prim-etc.cxx.o' -MF 'xsdump@exe/src_prim-etc.cxx.o.d' -o 'xsdump@exe/src_prim-etc.cxx.o' -c ../src/prim-etc.cxx
../src/prim-etc.cxx:8:10: fatal error: ffi.h: No such file or directory
#include <ffi.h>
         ^~~~~~~
```